### PR TITLE
Referência babel para  import do React em index.js

### DIFF
--- a/app/.eslintrc.json
+++ b/app/.eslintrc.json
@@ -1,3 +1,3 @@
 {
-  "extends": "next/core-web-vitals"
+  "extends": ["next/babel","next/core-web-vitals"]
 }


### PR DESCRIPTION
Adicionada a referência 'next/babel' em eslintrc.json para corrigir o erro no import do React em index.js